### PR TITLE
DRAW-89 Security Filter Token Authentication 오류 수정

### DIFF
--- a/app/support/auth/src/main/kotlin/com/xorker/draw/support/auth/core/JwtService.kt
+++ b/app/support/auth/src/main/kotlin/com/xorker/draw/support/auth/core/JwtService.kt
@@ -10,8 +10,8 @@ internal class JwtService(
     private val jwtProvider: JwtProvider,
     private val jwtSecretKey: JwtSecretKey,
 ) : TokenUseCase {
-    override fun getUserId(token: String): UserId {
-        val subject = jwtProvider.validateAndGetSubject(token, jwtSecretKey) ?: throw JwtValidationFailException
+    override fun getUserId(token: String): UserId? {
+        val subject = jwtProvider.validateAndGetSubject(token, jwtSecretKey) ?: return null
 
         return UserId(subject.toLong())
     }

--- a/app/support/auth/src/main/kotlin/com/xorker/draw/support/auth/core/JwtValidationFailException.kt
+++ b/app/support/auth/src/main/kotlin/com/xorker/draw/support/auth/core/JwtValidationFailException.kt
@@ -1,7 +1,0 @@
-package com.xorker.draw.support.auth.core
-
-import org.springframework.security.core.AuthenticationException
-
-internal data object JwtValidationFailException : AuthenticationException("Jwt validation 실패") {
-    private fun readResolve(): Any = JwtValidationFailException
-}

--- a/app/support/auth/src/main/kotlin/com/xorker/draw/support/auth/core/TokenUseCase.kt
+++ b/app/support/auth/src/main/kotlin/com/xorker/draw/support/auth/core/TokenUseCase.kt
@@ -3,5 +3,5 @@ package com.xorker.draw.support.auth.core
 import com.xorker.draw.user.UserId
 
 internal interface TokenUseCase {
-    fun getUserId(token: String): UserId
+    fun getUserId(token: String): UserId?
 }

--- a/app/support/auth/src/main/kotlin/com/xorker/draw/support/auth/security/SecurityConfig.kt
+++ b/app/support/auth/src/main/kotlin/com/xorker/draw/support/auth/security/SecurityConfig.kt
@@ -2,12 +2,14 @@ package com.xorker.draw.support.auth.security
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
+@EnableMethodSecurity
 @EnableWebSecurity
 @Configuration
 internal class SecurityConfig {

--- a/app/support/auth/src/main/kotlin/com/xorker/draw/support/auth/security/TokenAuthenticationFilter.kt
+++ b/app/support/auth/src/main/kotlin/com/xorker/draw/support/auth/security/TokenAuthenticationFilter.kt
@@ -14,7 +14,6 @@ import org.springframework.web.filter.OncePerRequestFilter
 internal class TokenAuthenticationFilter(
     private val tokenUseCase: TokenUseCase,
 ) : OncePerRequestFilter() {
-
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -22,8 +21,9 @@ internal class TokenAuthenticationFilter(
     ) {
         val accessToken = getAccessToken(request)
         if (accessToken != null) {
-            val userId = tokenUseCase.getUserId(accessToken)
-            setAuthentication(request, accessToken, userId)
+            tokenUseCase.getUserId(accessToken)?.let {
+                setAuthentication(request, accessToken, it)
+            }
         }
         filterChain.doFilter(request, response)
     }


### PR DESCRIPTION
### Related Jira ✔
- [Jira Ticket](https://xorker.atlassian.net/browse/DRAW-89)

### Description ✔
- authorizeHttpRequests 설정 시 요청 URL 경로가 permitAll()로 설정되어 있어서 Security Filter에서 AuthenticationException이 발생하여도 AuthenticationEntryPoint로 핸들링이 되지 않았습니다. 따라서 JwtService에서 AuthenticationException을 발생시키지 않도록 수정하였습니다.
- @PreAuthorize("isAuthenticated()")가 활성화 되도록 @EnableMethodSecurity를 적용하였습니다.

### PR Rule ✔
P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes)  
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)  