### PR TITLE
DRAW-94 WebSocket Auth 로직 추가

### DIFF
--- a/app/support/auth/build.gradle.kts
+++ b/app/support/auth/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 dependencies {
     implementation(project(":core"))
-    implementation(project(":support:jwt"))
 
     implementation("org.springframework.boot:spring-boot-starter-web:${Versions.SPRING_BOOT}")
     implementation("org.springframework.boot:spring-boot-starter-security:${Versions.SPRING_BOOT}")

--- a/app/support/auth/src/main/kotlin/com/xorker/draw/support/auth/security/TokenAuthenticationFilter.kt
+++ b/app/support/auth/src/main/kotlin/com/xorker/draw/support/auth/security/TokenAuthenticationFilter.kt
@@ -1,6 +1,6 @@
 package com.xorker.draw.support.auth.security
 
-import com.xorker.draw.support.auth.core.TokenUseCase
+import com.xorker.draw.auth.token.TokenUseCase
 import com.xorker.draw.user.UserId
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest

--- a/app/websocket/src/main/kotlin/com/xorker/draw/websocket/SessionFactory.kt
+++ b/app/websocket/src/main/kotlin/com/xorker/draw/websocket/SessionFactory.kt
@@ -1,5 +1,7 @@
 package com.xorker.draw.websocket
 
+import com.xorker.draw.auth.token.TokenUseCase
+import com.xorker.draw.exception.UnAuthenticationException
 import com.xorker.draw.room.RoomId
 import com.xorker.draw.user.User
 import com.xorker.draw.user.UserId
@@ -9,12 +11,14 @@ import org.springframework.stereotype.Service
 import org.springframework.web.socket.WebSocketSession
 
 @Service
-class SessionFactory {
+class SessionFactory(
+    private val tokenUseCase: TokenUseCase,
+) {
     fun create(session: WebSocketSession, request: SessionInitializeRequest): Session {
         return SessionWrapper(
             session,
-            RoomId(request.roomId?.toUpperCase() ?: generateRoomId()),
-            User(UserId(0), request.nickname), // TODO get User by AccessToken
+            RoomId(request.roomId?.uppercase() ?: generateRoomId()),
+            User(getUserId(request.accessToken), request.nickname),
         )
     }
 
@@ -26,5 +30,9 @@ class SessionFactory {
             .joinToString("")
 
         return value
+    }
+
+    private fun getUserId(token: String): UserId {
+        return tokenUseCase.getUserId(token) ?: throw UnAuthenticationException
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation(project(":adapter:memory"))
     implementation(project(":adapter:oauth"))
     implementation(project(":adapter:rdb"))
+    implementation(project(":support:jwt"))
 
     implementation("org.springframework.boot:spring-boot-starter:${Versions.SPRING_BOOT}")
     compileOnly("org.springframework.boot:spring-boot-starter-jdbc:${Versions.SPRING_BOOT}")

--- a/core/src/main/kotlin/com/xorker/draw/auth/token/JwtService.kt
+++ b/core/src/main/kotlin/com/xorker/draw/auth/token/JwtService.kt
@@ -1,4 +1,4 @@
-package com.xorker.draw.support.auth.core
+package com.xorker.draw.auth.token
 
 import com.xorker.draw.support.jwt.JwtProvider
 import com.xorker.draw.support.jwt.JwtSecretKey

--- a/core/src/main/kotlin/com/xorker/draw/auth/token/TokenUseCase.kt
+++ b/core/src/main/kotlin/com/xorker/draw/auth/token/TokenUseCase.kt
@@ -1,7 +1,7 @@
-package com.xorker.draw.support.auth.core
+package com.xorker.draw.auth.token
 
 import com.xorker.draw.user.UserId
 
-internal interface TokenUseCase {
+interface TokenUseCase {
     fun getUserId(token: String): UserId?
 }

--- a/core/src/main/kotlin/com/xorker/draw/config/JwtConfig.kt
+++ b/core/src/main/kotlin/com/xorker/draw/config/JwtConfig.kt
@@ -1,4 +1,4 @@
-package com.xorker.draw.support.auth.config
+package com.xorker.draw.config
 
 import com.xorker.draw.support.jwt.JwtProvider
 import com.xorker.draw.support.jwt.JwtSecretKey


### PR DESCRIPTION
### Related Jira ✔
- [Jira Ticket](https://xorker.atlassian.net/browse/DRAW-94)

### Description ✔
- token use case 로직을 core 모듈로 이동하였습니다.
- SessionFactory에 getUserId 메서드를 추가하였습니다. ws 메시지의 at 인증을 처리하고 userId를 가져올 수 있습니다.


### PR Rule ✔
P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes)  
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)  
